### PR TITLE
Fix hoisted imports

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import "./env.js";
+
 import express from 'express';
 const app = express();
 import configRoutes from './routes/index.js';
@@ -6,10 +8,6 @@ import {fileURLToPath} from 'url';
 import {dirname} from 'path';
 import exphbs from 'express-handlebars';
 import cookieParser from "cookie-parser";
-
-
-import dotenv from "dotenv"
-const result = dotenv.config(); // Can now access GOOGLE_MAPS_API_KEY using process.env.GOOGLE_MAPS_API_KEY
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/env.js
+++ b/env.js
@@ -1,0 +1,2 @@
+import dotenv from "dotenv"
+const result = dotenv.config(); // Can now access GOOGLE_MAPS_API_KEY using process.env.GOOGLE_MAPS_API_KEY


### PR DESCRIPTION
Why did I create this PR?
Even though I am putting jwtSigningKey in the .env file the server is crashing and it is because of hoisted imports in node.js. You can read more about it over here 
https://stackoverflow.com/questions/42817339/es6-import-happening-before-env-import

Apparently the imports in node js are executed first irrespective of the order of the code, because of which the mongoconnection.js and services/auth.js are being run before the dotenv.config in app.js, I have fixed it and tested it out with my .env file in local

How I fixed it?
Since the imports are hoisted, I am taking advantage of that by putting import statement in env.js which has to be executed before it moves on to the next import 